### PR TITLE
Add license-files to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "jinja2>=3.0.0,<4.0.0",


### PR DESCRIPTION
Add license-files entry to specify the LICENSE file. This will also ensure that it is properly included in the source distribution.